### PR TITLE
Improve solver robustness

### DIFF
--- a/Model/BodyModelConfig_LTHT.any
+++ b/Model/BodyModelConfig_LTHT.any
@@ -32,6 +32,41 @@ Main.Studies.InverseDynamicStudy =
    };
 };
 
+
+#ifndef SHOW_TRUNK
+  Main.HumanModel.BodyModel.Trunk.SegmentsThorax.ThoraxSeg.DrwSurf.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsThorax.SkullSeg.DrwSurf.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C7Seg.DrwSTL.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C6Seg.DrwSTL.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C5Seg.DrwSTL.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C4Seg.DrwSTL.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C3Seg.DrwSTL.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C2Seg.DrwSTL.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C1Seg.DrwSTL.Visible = Off;
+  
+  Main.HumanModel.BodyModel.Trunk.SegmentsThorax.SkullSeg.C1C0JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C1Seg.C1C0JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C2Seg.C2C1JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C3Seg.C3C2JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C4Seg.C4C3JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C5Seg.C5C4JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C6Seg.C6C5JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsCervicalSpine.C7Seg.C7C6JntNode.DrwNode.Visible = Off;
+  Main.HumanModel.BodyModel.Trunk.SegmentsThorax.ThoraxSeg.T1C7JntNode.DrwNode.Visible = Off;
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
 //#ifdef BM_LEG_MUSCLES_BOTH_HILL
 //#define BM_LEG_MUSCLES_BOTH _MUSCLES_3E_HILL_
 //#endif

--- a/Model/ExtraDrivers_LTHT.any
+++ b/Model/ExtraDrivers_LTHT.any
@@ -25,9 +25,19 @@ Main.EnvironmentModel.GlobalRef = {
    #endif
 #endif
 
+// Add very weak soft drivers for the upper body 
+// to help in the situations where markers are missing. 
 
-
-
+  #define BM_MANNEQUIN_DRIVER_PELVIS_THORAX_LATERAL_BENDING ON
+ 
+  #define BM_MANNEQUIN_DRIVER_PELVIS_THORAX_ROTATION	ON
+  #define BM_MANNEQUIN_DRIVER_PELVIS_THORAX_EXTENSION	ON
+  Main.HumanModel.DefaultMannequinDrivers = 
+  {
+    PostureDriverBending.WeakDriverWeight = 0.001;
+    PostureDriverRotation.WeakDriverWeight = 0.001;
+    PostureDriverExtension.WeakDriverWeight = 0.001; 
+  };
 
 AnyFolder ExtraDrivers = {
    AnyFolder &JntPos= Main.HumanModel.Mannequin.Posture;  

--- a/Model/LabSpecificData_LTHT.any
+++ b/Model/LabSpecificData_LTHT.any
@@ -17,6 +17,7 @@ Main.ModelSetup.LabSpecificData =
  ///////      MOCAP BODYMODEL CONFIGURATION        ///////     
  #path BODY_MODEL_CONFIG_FILE "BodyModelConfig_LTHT.any"
 
+ Main.Studies.MarkerTracking.Kinematics.KinematicTol = 1e-5;
 
  #ifndef MOCAP_OUTPUT_FILENAME_PREFIX 
  #define MOCAP_OUTPUT_FILENAME_PREFIX Main.ModelSetup.SubjectSpecificData.SubjectID + "_"


### PR DESCRIPTION
@depierie I tried to improve the robustness of running all simulation. It seems to work a lot better if there are soft, but very weak, drivers on the upper body. This has no effect on the results. 

I have also hidden the upper body by default. I think it gives nicer images of the mode. 